### PR TITLE
Fix for ruby 2 6 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,9 @@ source 'https://rubygems.org'
 
 gem 'rspec', '2.14.1'
 gem 'pry'
-gem 'chipmunk'
+gem 'rake'
+gem 'rake-compiler', require: false
+
+# group :spec do
+  gem 'chipmunk', require: false, path: './'
+# end

--- a/README
+++ b/README
@@ -1,5 +1,12 @@
 Ruby Bindings to Chipmunk Physics Version 6.1.3
 
+
+*********************************************************************************
+** This project is currently unmaintained.  If you are interested in taking it **
+** over, please open an issue.                                                 **
+*********************************************************************************
+
+
 (C) Scott Lembcke, Beoran, John Mair (banisterfiend) and Shawn Anderson (shawn42)
 
 IMPORTANT NOTICE:
@@ -43,7 +50,7 @@ REQUIREMENTS
   * 1.9.x.
   * rspec for running the specs.
   * rake and rake-compiler for compiling the extension.
-  
+
 
 INSTALLATION
   Clone this repository and do:
@@ -74,10 +81,10 @@ CHANGES:
   * Since 5.3.4.1: Vendored chipmunk again, cleanly. Several bugfixes.
   * Since 5.1.0  : Much more of Chipmunk's functionality is wrapped. Unvendored
     chipmunk. More specs and documentation.
-    
+
 VERSIONING POLICY:
-  Since 6.1.3.0 these bindings follow the version of chipmunk, followed by an 
-  extra number for the version of the bindings. All major releases will be 
+  Since 6.1.3.0 these bindings follow the version of chipmunk, followed by an
+  extra number for the version of the bindings. All major releases will be
   backwards compatible in their API. The API may be enhanced in minor releases.
 
 KNOWN BUGS:
@@ -110,6 +117,6 @@ INFO FOR MAINTAINERS:
     * Install 1.9.1 mingw ruby versions (instructions above)
     * Type: rake cross native gem RUBY_CC_VERSION=1.9.1
     * Upload new gems to rubygems
-    
+
 
 Join the chat at https://gitter.im/beoran/chipmunk

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,16 @@
-require 'rake'
-require 'rake/clean'
 require 'rubygems'
 require 'rubygems/package_task'
+require 'rake'
+require 'rake/clean'
+require 'pry'
 
 CHIPMUNK_VERSION = "6.1.3.3"
 dlext = RbConfig::CONFIG['DLEXT']
 
 CLEAN.include("ext/**/*.#{dlext}", "ext/**/.log", "ext/**/.o", "ext/**/*~", "ext/**/*#*", "ext/**/.obj", "ext/**/.def", "ext/**/.pdb")
 CLOBBER.include("**/*.#{dlext}", "**/*~", "**/*#*", "**/*.log", "**/*.o", "doc/**")
+
+require 'mkmf'
+require 'rake/extensiontask'
+Rake::ExtensionTask.new('chipmunk')
 

--- a/ext/chipmunk/rb_cpSpace.c
+++ b/ext/chipmunk/rb_cpSpace.c
@@ -410,7 +410,7 @@ static VALUE
 rb_cpSpaceResizeActiveHash(VALUE self, VALUE dim, VALUE count) {
   rb_raise(rb_eArgError, "resize_active_hash is obsolete");
   return Qnil;
-  /* cpSpaceResizeActiveHash(SPACE(self), NUM2DBL(dim), NUM2INT(count));  
+  /* cpSpaceResizeActiveHash(SPACE(self), NUM2DBL(dim), NUM2INT(count));
   return Qnil;
   */
 }
@@ -473,7 +473,7 @@ rb_cpSpacePointQueryFirst(int argc, VALUE *argv, VALUE self) {
 
 static void
 segmentQueryCallback(cpShape *shape, cpFloat t, cpVect n, VALUE block) {
-  rb_funcall(block, id_call, 1, (VALUE)shape->data, rb_float_new(t), VNEW(n));
+  rb_funcall(block, id_call, 3, (VALUE)shape->data, rb_float_new(t), VNEW(n));
 }
 
 static VALUE
@@ -629,7 +629,7 @@ Init_cpSpace(void) {
   rb_define_method(c_cpSpace, "collision_slop=", rb_cpSpace_set_collisionSlop, 1);
   rb_define_method(c_cpSpace, "collision_persistence", rb_cpSpace_get_collisionPersistence, 0);
   rb_define_method(c_cpSpace, "collision_persistence=", rb_cpSpace_set_collisionPersistence, 1);
-  
+
   rb_define_method(c_cpSpace, "add_shape", rb_cpSpaceAddShape, 1);
   rb_define_method(c_cpSpace, "add_static_shape", rb_cpSpaceAddStaticShape, 1);
   rb_define_method(c_cpSpace, "add_body", rb_cpSpaceAddBody, 1);

--- a/lib/chipmunk.rb
+++ b/lib/chipmunk.rb
@@ -1,11 +1,11 @@
-require 'chipmunk/chipmunk'
+require_relative 'chipmunk.so'
 require_relative 'version'
 
 module CP
   ZERO_VEC_2 = Vec2.new(0,0).freeze
   ALL_ONES   = Vec2.new(1,1).freeze
-end  
- 
+end
+
 # Extra functionality added by Slembkce and Beoran.
 
 module CP
@@ -25,7 +25,7 @@ module CP
         raise "This CP::Object (#{self.class}) did not call #init_chipmunk_object."
       end
     end
-    
+
     private
     # Should be called during initialization of a CP::Object to set what primitive
     # and composite Chipmunk objects this object references.
@@ -37,91 +37,91 @@ module CP
       @chipmunk_objects = objs.inject([]){|sum, obj| sum + obj.chipmunk_objects}.uniq
     end
   end
-  
+
   class Body
     include CP::Object
 
     def chipmunk_objects
       [self]
     end
-    
+
     def add_to_space(space)
       space.add_body(self)
     end
-    
+
     def remove_from_space(space)
       space.remove_body(self)
     end
-    
+
   end
-  
+
   module Shape
     include CP::Object
-    
+
     def chipmunk_objects
       [self]
     end
-    
+
     def add_to_space(space)
       space.add_shape(self)
     end
-    
+
     def remove_from_space(space)
       space.remove_shape(self)
     end
   end
-    
+
   module Constraint
     include CP::Object
-    
+
     def chipmunk_objects
       [self]
     end
-    
+
     def add_to_space(space)
       space.add_constraint(self)
     end
-    
+
     def remove_from_space(space)
       space.remove_constraint(self)
     end
   end
-  
+
   class Space
     def add_object(obj)
       obj.chipmunk_objects.each{|elt| elt.add_to_space(self)}
     end
-    
+
     def add_objects(*objs)
       objs.each{|obj| add_object(obj)}
     end
-    
+
     def remove_object(obj)
       obj.chipmunk_objects.each{|elt| elt.remove_from_space(self)}
     end
-    
+
     def remove_objects(*objs)
       objs.each{|obj| remove_object(obj)}
     end
-    
+
   end
-  
+
   class Vec2
     ZERO = Vec2.new(0,0).freeze
   end
-  
+
   # define the helpers here( easier than in the extension.
   class SegmentQueryInfo
     def hit_point(start, stop)
       return start.lerp(stop, self.t)
     end
-    
+
     def hit_dist(start, stop)
       return start.dist(stop) * self.t
     end
-  end  
-  
-  
+  end
+
+
 end
 
 
@@ -131,31 +131,31 @@ module CP
     def initialize
       super(Float::INFINITY, Float::INFINITY)
     end
-    
+
     def chipmunk_objects
       # return [] instead of [self] so the static body will not be added.
       []
     end
   end
-  
+
   class StaticBody
     def chipmunk_objects
       # return [] instead of [self] so the static body will not be added.
       []
     end
   end
-  
+
   module StaticShape
     include Shape
-    
+
     class Circle < Shape::Circle
       include StaticShape
     end
-    
+
     class Segment < Shape::Segment
       include StaticShape
     end
-    
+
     class Poly < Shape::Poly
       include StaticShape
     end
@@ -163,13 +163,13 @@ module CP
     def add_to_space(space)
       space.add_static_shape(self)
     end
-    
+
     def remove_from_space(space)
       space.remove_static_shape(self)
     end
   end
 end
- 
+
 
 
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-# require 'rspec'
+require 'rspec'
 # $:.unshift File.join(File.dirname(File.dirname(__FILE__)), 'lib')
 
 require 'chipmunk'


### PR DESCRIPTION
I fixed things so this compiles in ruby 2.6.2.  Tests pass.  It still works for me in 2.3.3.  The tl;dr of the bug is that `rb_funcall` gets hostile if you tell it you're passing one arg but you actually pass it three.

I fixed a couple other things along the way.  
* rake-compile was missing so I set that up so I could compile.
* Test setup was weird.  It was requiring chipmunk as an external dependency, so I don't think I was testing against my code changes.  I believe that's fixed now.

Also added a note to the readme to say that the project is unmaintained and looking for a maintainer.

Cheers!